### PR TITLE
Fix RSS Feed

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -19,10 +19,11 @@ Future<void> main(List<String> arguments) async {
       showDrafts: arguments.contains("preview"),
     ))
     ..plugin(RssPlugin(
+      includePagesByDefault: false,
       site: RssSiteConfiguration(
         title: "Flutter Foundation",
         description: "By the Flutter community, for the Flutter community.",
-        homePageUrl: "https://getflocked.dev/blog/",
+        homePageUrl: "https://getflocked.dev",
       ),
       pageToRssItemMapper: (RssSiteConfiguration config, Page page) {
         return defaultPageToRssItemMapper(config, page)?.copyWith(

--- a/source/blog/posts/_data.yaml
+++ b/source/blog/posts/_data.yaml
@@ -1,2 +1,3 @@
 tags: post
 layout: layouts/post.jinja
+rss: true


### PR DESCRIPTION
The RSS feed is currently broken: it shows all pages from the website, not just blog posts, and the URL for posts is wrong.

Currently, a post's URL looks like this:

```
https://getflocked.dev/blog///blog/posts/talking-flock-with-viktor-lidholt/
```

To fix the RSS feed containing all pages, I excluded them by default and included only blog posts using the data.yaml. I also fixed the URL of the posts by removing the path from the website's URL in the RSS configuration.

Now, the URL looks like this:

```
https://getflocked.dev//blog/posts/talking-flock-with-viktor-lidholt/
``` 

I did not find a way to remove the double slash, but I don't think it will be an issue for most browsers. If you know how to remove it please point me in the correct direction.