### PR TITLE
Fix broken links in contribute section

### DIFF
--- a/source/flock/contribute/contribute-a-change.md
+++ b/source/flock/contribute/contribute-a-change.md
@@ -5,7 +5,7 @@ title: Contribute a Change
 Thanks for your interest in contributing to Flock. Every change to Flock is contributed through 
 something called a "patch file". This guide shows you how to contribute patch files for review.
 
-If you're just getting started with Flock, see the [setup guide](setup-to-contribute.md) to
+If you're just getting started with Flock, see the [setup guide](/flock/contribute/setup-to-contribute) to
 begin contributing.
 
 ## Create a commit for your changes

--- a/source/flock/contribute/setup-to-contribute.md
+++ b/source/flock/contribute/setup-to-contribute.md
@@ -62,4 +62,4 @@ Once this command completes, your `nest/flock/` directory contains the latest ve
 of Flock, and it's ready for development.
 
 ## Submit your changes
-When you're ready to submit your changes to Flock, follow the steps in [contribute a change](contribute-a-change).
+When you're ready to submit your changes to Flock, follow the steps in [contribute a change](/flock/contribute/contribute-a-change).


### PR DESCRIPTION
The "setup guide" link in the Contribute A Change page and the "contribute a change" link in the Setup To Contribute page currently lead to a 404 page. 

This PR fixes them. 